### PR TITLE
Fix correction target tests

### DIFF
--- a/python/PiFinder/polar_alignment.py
+++ b/python/PiFinder/polar_alignment.py
@@ -49,6 +49,8 @@ from scipy.optimize import minimize
 from skyfield.framelib import (
     true_equator_and_equinox_of_date as _SKYFIELD_TETE_FRAME,
 )
+from skyfield.api import Loader as _skyfield_Loader
+from pathlib import Path as pathlib_Path
 
 logger = logging.getLogger("PiFinder.polar_alignment")
 
@@ -59,8 +61,6 @@ logger = logging.getLogger("PiFinder.polar_alignment")
 # the caller can report it to the user and ask for more platform rotation.
 MIN_SWEEP_DEG = 3.0
 
-from skyfield.api import Loader as _skyfield_Loader
-from pathlib import Path as pathlib_Path
 _SCRIPT_DIR = pathlib_Path(__file__).resolve().parent
 _ASTRODATA_PATH = str((_SCRIPT_DIR / '..' / '..' / 'astro_data').resolve())
 print(f"Astro data path: {_ASTRODATA_PATH}")

--- a/python/tests/test_polar_alignment.py
+++ b/python/tests/test_polar_alignment.py
@@ -56,7 +56,8 @@ def _true_axis(latitude, dAlt, dAz, lst_deg):
     else:
         alt = np.radians(abs(latitude) + dAlt)
         az = np.radians(180.0 + dAz)
-    dec = np.arcsin(np.sin(lat) * np.sin(alt) + np.cos(lat) * np.cos(alt) * np.cos(az))
+    dec = (np.arcsin(np.sin(lat) * np.sin(alt)
+                     + np.cos(lat) * np.cos(alt) * np.cos(az)))
     ha = np.arctan2(
         -np.cos(alt) * np.sin(az),
         np.cos(lat) * np.sin(alt) - np.sin(lat) * np.cos(alt) * np.cos(az),
@@ -67,8 +68,10 @@ def _true_axis(latitude, dAlt, dAz, lst_deg):
 
 
 def _three_solves(ra1, dec1, latitude, dAlt, dAz, sweep_total, lst_deg):
-    s2 = make_solve_2(ra1, dec1, 0.0, latitude, dAlt, dAz, sweep_total / 2, lst_deg)
-    s3 = make_solve_2(ra1, dec1, 0.0, latitude, dAlt, dAz, sweep_total, lst_deg)
+    s2 = make_solve_2(ra1, dec1, 0.0, latitude, dAlt, dAz,
+                      sweep_total / 2, lst_deg)
+    s3 = make_solve_2(ra1, dec1, 0.0, latitude, dAlt, dAz,
+                      sweep_total, lst_deg)
     return [(ra1, dec1, 0.0, 0), (*s2, 0), (*s3, 0)]
 
 
@@ -229,7 +232,8 @@ class TestThreeSolve:
                 sigma_roll=sigma_roll,
             )
             err = np.degrees(
-                np.arccos(np.clip(np.dot(_axis_vec(ax_ra, ax_dec), true_ax), -1, 1))
+                np.arccos(np.clip(np.dot(_axis_vec(ax_ra, ax_dec), true_ax),
+                                  -1, 1))
             )
             errs.append(err * 60)
             fqs.append(fq)
@@ -306,7 +310,8 @@ class TestPrecession:
             observation_jyear=jyear_c,
         )
         _ts_c = _SKYFIELD_TS.J(jyear_c)
-        _ncp = _SKYFIELD_TETE_FRAME.rotation_at(_ts_c) @ np.array([0.0, 0.0, 1.0])
+        _ncp = (_SKYFIELD_TETE_FRAME.rotation_at(_ts_c)
+                @ np.array([0.0, 0.0, 1.0]))
         gt_ra_c = np.degrees(np.arctan2(_ncp[1], _ncp[0])) % 360
         gt_dec_c = np.degrees(np.arcsin(np.clip(_ncp[2], -1, 1)))
         exp_axis = _axis_vec(gt_ra_c, gt_dec_c)
@@ -330,11 +335,13 @@ class TestCorrectionTarget:
         _, _, _, ax_ra, ax_dec, _ = get_platform_adjustments(
             [(ra_pt, dec_pt, 0.0, 0), (ra_pt, dec_pt, 14.0, 0)], LAT_NH, LST
         )
-        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0), LAT_NH, LST)
+        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0),
+                                        LAT_NH, LST)
         assert dec_t == pytest.approx(90.0, abs=1e-4)
 
     def test_aligned_axis_is_identity(self):
-        ra_t, dec_t, roll_t = correction_target(0.0, 90.0, (180.0, 30.0, 5.0), LAT_NH, LST)
+        ra_t, dec_t, roll_t = correction_target(0.0, 90.0, (180.0, 30.0, 5.0),
+                                                LAT_NH, LST)
         assert ra_t == pytest.approx(180.0, abs=1e-9)
         assert dec_t == pytest.approx(30.0, abs=1e-9)
         assert roll_t == pytest.approx(5.0, abs=1e-9)
@@ -342,7 +349,8 @@ class TestCorrectionTarget:
     def test_antipodal_axis(self):
         # Axis pointing exactly at the SCP; the correction rotation must map
         # it to the NCP, carrying the boresight from dec=-30 to dec=+30.
-        _, dec_t, _ = correction_target(0.0, -90.0, (180.0, -30.0, 0.0), LAT_NH, LST)
+        _, dec_t, _ = correction_target(0.0, -90.0, (180.0, -30.0, 0.0),
+                                        LAT_NH, LST)
         assert dec_t == pytest.approx(30.0, abs=1e-6)
 
     def test_roll_survives_precession_round_trip(self):
@@ -350,15 +358,17 @@ class TestCorrectionTarget:
         # coordinates) the correction (in solar reference) is identity,
         # so the J2000 input must come back almost unchanged
 
-        # correction_target now corrects the J2000 target for annual aberration,
-        # (solar->earth reference frame) which can wiggle Ra and Dec coordinates 20",
+        # correction_target now corrects the J2000 target for annual
+        # aberration, (solar->earth reference frame)
+        # which can wiggle Ra and Dec coordinates 20",
         # so we need to allow for 30" separation.
-     
+
         # Note: the annual aberration correction can *severely* change
         # roll very close to the pole, it will stay under 20" with Dec < 45°
-        
+
         ra_t, dec_t, roll_t = correction_target(
-            0.0, 90.0, (180.0, 30.0, 45.0), LAT_NH, LST, observation_jyear=2026.44
+            0.0, 90.0, (180.0, 30.0, 45.0),
+            LAT_NH, LST, observation_jyear=2026.44
         )
         sep_arcsec = (
             np.degrees(np.arccos(np.clip(np.dot(_axis_vec(ra_t, dec_t),
@@ -380,7 +390,8 @@ class TestCorrectionTarget:
         _, _, _, ax_ra, ax_dec, _ = get_platform_adjustments(
             [(ra_pt, dec_pt, 0.0, 0), (ra_pt, dec_pt, 14.0, 0)], LAT_SH, LST
         )
-        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0), LAT_SH, LST)
+        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0),
+                                        LAT_SH, LST)
         assert dec_t == pytest.approx(-90.0, abs=1e-4)
 
     def test_j2000_pole_axis_target_back_precessed(self):
@@ -402,19 +413,21 @@ class TestCorrectionTarget:
             observation_jyear=jyear_c,
         )
         ra_t, dec_t, _ = correction_target(
-            ax_ra, ax_dec, (0.0, 90.0, 14.0), LAT_NH, LST, observation_jyear=jyear_c
+            ax_ra, ax_dec, (0.0, 90.0, 14.0),
+            LAT_NH, LST, observation_jyear=jyear_c
         )
-        # Ground truth: TETE Dec=90° (JNOW NCP) expressed in ICRS/J2000, recovered through astropy
-        # i.e. the JNOW *apparent* pole back-rotated through the precession matrix.
-        # We're pointing right to the pole, so the target needs to be the apparent pole:
-        # we want the mount to point to the *geometric* pole but for that the plate solver
-        # must appear to point to the *apparent* pole
+        # Ground truth: TETE Dec=90° (JNOW NCP) expressed in ICRS/J2000,
+        # recovered through astropy i.e. the JNOW *apparent* pole back-rotated
+        # through the precession matrix.
+        # We're pointing right to the pole, so the target needs to be
+        # the apparent pole.
         # With sweeps further from the pole we need less correction
-        gt_ra_c  = 1.0848564758628065
+        gt_ra_c = 1.0848564758628065
         gt_dec_c = 89.85753549689021
         gt_vec_c = _axis_vec(gt_ra_c, gt_dec_c)
 
-        # Near Dec=90° RA in degrees is not meaningful — compare by angular separation
+        # Near Dec=90° RA in degrees is not meaningful — compare by angular
+        # separation
         t_vec_c = _axis_vec(ra_t, dec_t)
         sep_arcsec = (
             np.degrees(np.arccos(np.clip(np.dot(t_vec_c, gt_vec_c), -1, 1)))

--- a/python/tests/test_polar_alignment.py
+++ b/python/tests/test_polar_alignment.py
@@ -330,11 +330,11 @@ class TestCorrectionTarget:
         _, _, _, ax_ra, ax_dec, _ = get_platform_adjustments(
             [(ra_pt, dec_pt, 0.0, 0), (ra_pt, dec_pt, 14.0, 0)], LAT_NH, LST
         )
-        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0))
+        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0), LAT_NH, LST)
         assert dec_t == pytest.approx(90.0, abs=1e-4)
 
     def test_aligned_axis_is_identity(self):
-        ra_t, dec_t, roll_t = correction_target(0.0, 90.0, (180.0, 30.0, 5.0))
+        ra_t, dec_t, roll_t = correction_target(0.0, 90.0, (180.0, 30.0, 5.0), LAT_NH, LST)
         assert ra_t == pytest.approx(180.0, abs=1e-9)
         assert dec_t == pytest.approx(30.0, abs=1e-9)
         assert roll_t == pytest.approx(5.0, abs=1e-9)
@@ -342,7 +342,7 @@ class TestCorrectionTarget:
     def test_antipodal_axis(self):
         # Axis pointing exactly at the SCP; the correction rotation must map
         # it to the NCP, carrying the boresight from dec=-30 to dec=+30.
-        _, dec_t, _ = correction_target(0.0, -90.0, (180.0, -30.0, 0.0))
+        _, dec_t, _ = correction_target(0.0, -90.0, (180.0, -30.0, 0.0), LAT_NH, LST)
         assert dec_t == pytest.approx(30.0, abs=1e-6)
 
     def test_roll_survives_precession_round_trip(self):
@@ -358,7 +358,7 @@ class TestCorrectionTarget:
         # roll very close to the pole, it will stay under 20" with Dec < 45°
         
         ra_t, dec_t, roll_t = correction_target(
-            0.0, 90.0, (180.0, 30.0, 45.0), observation_jyear=2026.44
+            0.0, 90.0, (180.0, 30.0, 45.0), LAT_NH, LST, observation_jyear=2026.44
         )
         sep_arcsec = (
             np.degrees(np.arccos(np.clip(np.dot(_axis_vec(ra_t, dec_t),
@@ -380,7 +380,7 @@ class TestCorrectionTarget:
         _, _, _, ax_ra, ax_dec, _ = get_platform_adjustments(
             [(ra_pt, dec_pt, 0.0, 0), (ra_pt, dec_pt, 14.0, 0)], LAT_SH, LST
         )
-        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0))
+        _, dec_t, _ = correction_target(ax_ra, ax_dec, (ra_pt, dec_pt, 14.0), LAT_SH, LST)
         assert dec_t == pytest.approx(-90.0, abs=1e-4)
 
     def test_j2000_pole_axis_target_back_precessed(self):
@@ -397,12 +397,12 @@ class TestCorrectionTarget:
 
         _, _, _, ax_ra, ax_dec, _ = get_platform_adjustments(
             [(0.0, 90.0, 0.0, 0), (0.0, 90.0, 14.0, 0)],
-            51.2,
-            0.0,
+            LAT_NH,
+            LST,
             observation_jyear=jyear_c,
         )
         ra_t, dec_t, _ = correction_target(
-            ax_ra, ax_dec, (0.0, 90.0, 14.0), observation_jyear=jyear_c
+            ax_ra, ax_dec, (0.0, 90.0, 14.0), LAT_NH, LST, observation_jyear=jyear_c
         )
         # Ground truth: TETE Dec=90° (JNOW NCP) expressed in ICRS/J2000, recovered through astropy
         # i.e. the JNOW *apparent* pole back-rotated through the precession matrix.

--- a/python/tests/test_ui_modules.py
+++ b/python/tests/test_ui_modules.py
@@ -36,8 +36,9 @@ autouse session fixture:
   * ``time.sleep`` -> no-op (the SQM wizards are per-update capture state
     machines that sleep on every frame; otherwise the sweep takes minutes).
 All UI logic itself stays real. (``UIStatus``'s ``/sys`` read is already
-``try/except``-guarded.) ``UIChart`` / ``UIAlign`` need ``hip_main.dat``, which
-ships in the repo under ``astro_data/``; those cases skip if it is ever missing.
+``try/except``-guarded.) ``UIChart`` / ``UIAlign`` need ``hip_main.dat``,
+which ships in the repo under ``astro_data/``; those cases skip
+if it is ever missing.
 
 Run from ``python/`` (paths in ``PiFinder.utils`` are relative to CWD):
     pytest -m integration tests/test_ui_modules.py
@@ -93,7 +94,7 @@ from PiFinder.ui.sqm_correction import UISQMCorrection
 # Constants
 # --------------------------------------------------------------------------- #
 
-# command_queues keys main.py wires up; modules .put() onto these (no consumer).
+# command_queues keys main.py wires up; modules .put() onto these (no consumer)
 _COMMAND_QUEUE_KEYS = (
     "camera",
     "console",
@@ -103,17 +104,18 @@ _COMMAND_QUEUE_KEYS = (
     "gps",
 )
 
-# Modules that need the Hipparcos catalogue to construct (build plot.Starfield).
+# Modules that need the Hipparcos catalogue to construct (build plot.Starfield)
 _HIP_REQUIRED = {"UIChart", "UIAlign"}
 
 # Modules the generic sweep can't fairly exercise, with the reason. These are
 # still constructed and covered by the completeness guard -- only the key sweep
 # is skipped. UIAlign is a stateful alignment wizard: its update()/key handlers
 # assume a live solve has populated self.solution and self.visible_stars via a
-# prior successful starfield plot, which a generic isolated sweep can't provide.
-# It warrants dedicated alignment-flow tests instead.
+# prior successful starfield plot, which a generic isolated sweep
+# can't provide. It warrants dedicated alignment-flow tests instead.
 _SWEEP_SKIP: dict[str, str] = {
-    "UIAlign": "needs a live solve + alignment-star sequence; cover via dedicated tests",
+    "UIAlign": "needs a live solve + alignment-star sequence; "
+    "cover via dedicated tests",
 }
 
 # UIModule subclasses that are intentionally *not* exercised, with the reason.
@@ -122,7 +124,8 @@ _COVERAGE_SKIP: dict[str, str] = {
     # (none currently -- UISQMCorrection is covered via the dynamic fixtures)
 }
 
-# Bound on the auto-sweep so a handler that keeps pushing modules can't run away.
+# Bound on the auto-sweep so a handler that keeps pushing modules
+# can't run away.
 _MAX_SWEEP_MODULES = 80
 
 
@@ -216,7 +219,8 @@ def _build_dynamic_item_definition(spec_id: str, sample_object) -> dict:
         # sqm.py:302
         return {"name": "SQM Sweep", "class": UISQMSweep, "label": "sqm_sweep"}
     if spec_id == "UISQMCorrection":
-        # No launch site in the tree; best-effort fixture (constructs from sqm()).
+        # No launch site in the tree; best-effort fixture
+        # (constructs from sqm()).
         return {
             "name": "SQM Correction",
             "class": UISQMCorrection,
@@ -248,17 +252,18 @@ def _all_uimodule_subclasses() -> set[str]:
 
 @pytest.fixture(scope="session", autouse=True)
 def _require_data_files():
-    """Skip the whole module if not run from python/ (paths are CWD-relative)."""
+    """Skip the whole module if not run from python/
+    (paths are CWD-relative)."""
     if not utils.pifinder_db.exists():
         pytest.skip(
-            f"{utils.pifinder_db} not found -- run the UI harness from python/ "
-            "(astro_data paths are relative to CWD)."
+            f"{utils.pifinder_db} not found -- run the UI harness from python/"
+            " (astro_data paths are relative to CWD)."
         )
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _sandbox_data_dir(tmp_path_factory):
-    """Redirect the user data dir to a temp dir so no test writes real settings.
+    """Redirect user data dir to a temp dir so no test writes real settings.
 
     Copies the developer's config.json in (reads stay realistic) but points all
     writes -- config, observations DB, debug dumps -- at the sandbox.
@@ -274,8 +279,10 @@ def _sandbox_data_dir(tmp_path_factory):
 
     with (
         mock.patch.object(utils, "data_dir", sandbox),
-        mock.patch.object(utils, "observations_db", sandbox / "observations.db"),
-        mock.patch.object(utils, "debug_dump_dir", sandbox / "solver_debug_dumps"),
+        mock.patch.object(utils, "observations_db",
+                          sandbox / "observations.db"),
+        mock.patch.object(utils, "debug_dump_dir",
+                          sandbox / "solver_debug_dumps"),
     ):
         yield sandbox
 
@@ -293,9 +300,10 @@ def _fast_timezonefinder():
 
     SharedStateObj.__init__ builds a fresh TimezoneFinder (loads a multi-MB
     timezone binary), and the harness constructs a SharedStateObj per test
-    (cold/warm). The real init is cheap-ish on a dev box but brutally slow on a
-    CI runner -- hundreds of inits take ~10 min and look like a hang. Timezone
-    resolution is irrelevant to UI crash-smoke, so a constant-"UTC" stub is fine.
+    (cold/warm). The real init is cheap-ish on a dev box but brutally slow
+    on a CI runner -- hundreds of inits take ~10 min and look like a hang.
+    Timezone resolution is irrelevant to UI crash-smoke,
+    so a constant-"UTC" stub is fine.
     """
     with mock.patch("PiFinder.state.TimezoneFinder", _StubTimezoneFinder):
         yield
@@ -309,8 +317,8 @@ def _fast_sleep():
     machines that sleep 0.2-0.5s on every frame while driving the real camera.
     Driven by the key sweep with no camera process, those sleeps add up to
     minutes of pure wall-clock waiting. None of these modules busy-loop on a
-    condition (no ``while``+sleep), so removing the waits is safe and changes no
-    logic -- we only care that nothing raises.
+    condition (no ``while``+sleep), so removing the waits is safe and changes
+    no logic -- we only care that nothing raises.
     """
     with mock.patch("time.sleep", lambda *a, **k: None):
         yield
@@ -318,7 +326,8 @@ def _fast_sleep():
 
 @pytest.fixture(scope="session", autouse=True)
 def _no_network():
-    """Stub UISoftware's live GitHub version check (the one hard network call)."""
+    """Stub UISoftware's live GitHub version check
+    the one hard network call)."""
     fake = mock.Mock()
     fake.text = "1.0.0"
     fake.status_code = 200
@@ -330,10 +339,11 @@ def _no_network():
 def _no_comet_download():
     """Stop the comet catalog from downloading over the network.
 
-    CometCatalog.__init__ spawns a daemon thread that fetches the comet TSV via
-    requests.get during CatalogBuilder.build(). Stub the network function to
-    report "no download" (success=False); the real catalog/threading logic stays
-    intact and just loads no comets, keeping the suite hermetic.
+    CometCatalog.__init__ spawns a daemon thread that fetches the comet TSV
+    via requests.get during CatalogBuilder.build().
+    Stub the network function to report "no download" (success=False);
+    the real catalog/threading logic stays intact
+    and just loads no comets, keeping the suite hermetic.
     """
     import PiFinder.comets as comets
 
@@ -349,10 +359,11 @@ def _inert_sys_utils():
 
     sys_utils is the OS/hardware action layer: shutdown(), restart_system(),
     switch_cam_*(), go_wifi_*(), update_software(). The key sweep selects menu
-    items, which fire these as real actions -- on a Pi this harness would reboot
-    or reconfigure the device, and off-Pi sys_utils_fake is missing some of them
-    (e.g. switch_cam_imx462). Replace it with an inert mock everywhere the UI
-    imported it, so actions are safe no-ops while all UI logic stays real.
+    items, which fire these as real actions -- on a Pi this harness would
+    reboot or reconfigure the device, and off-Pi sys_utils_fake is missing
+    some of them (e.g. switch_cam_imx462).
+    Replace it with an inert mock everywhere the UI imported it,
+    so actions are safe no-ops while all UI logic stays real.
     """
     inert = mock.MagicMock(name="sys_utils")
     with (
@@ -389,9 +400,9 @@ def _no_preload():
     """Disable MenuManager's chart/align preload.
 
     Preloading constructs plot.Starfield (needs hip_main.dat) at *every*
-    MenuManager construction, which would couple all cases to Hipparcos. With it
-    off, chart/align are constructed on demand only when their own node is the
-    case under test, and gated behind hip_main_available.
+    MenuManager construction, which would couple all cases to Hipparcos.
+    With it off, chart/align are constructed on demand only when
+    their own node is the case under test, and gated behind hip_main_available.
     """
     with mock.patch.object(MenuManager, "preload_modules", lambda self: None):
         yield
@@ -413,9 +424,10 @@ def catalogs(_no_comet_download) -> Iterator[Catalogs]:
     """Build the real catalogs once from the bundled DB.
 
     Teardown stops the perpetual catalog timers. The planet and comet catalogs
-    run a self-rescheduling, *non-daemon* threading.Timer (via TimerMixin); left
-    running they keep the interpreter alive at shutdown, so `nox -s ui_tests`
-    would never exit. Stopping them on teardown lets the process end cleanly.
+    run a self-rescheduling, *non-daemon* threading.Timer (via TimerMixin);
+    left running they keep the interpreter alive at shutdown,
+    so `nox -s ui_tests` would never exit.
+    Stopping them on teardown lets the process end cleanly.
     """
     boot_state = SharedStateObj()
     boot_state.set_ui_state(UIState())
@@ -444,8 +456,8 @@ def sample_object(catalogs):
 def hip_main_available() -> bool:
     """Whether the Hipparcos catalog is present (it ships in the repo).
 
-    Kept as a defensive guard: if astro_data/hip_main.dat is ever missing, the
-    chart/align cases skip instead of erroring.
+    Kept as a defensive guard: if astro_data/hip_main.dat is ever missing,
+    the chart/align cases skip instead of erroring.
     """
     return (utils.astro_data_dir / "hip_main.dat").exists()
 
@@ -468,13 +480,16 @@ def _make_shared_state(state: str) -> SharedStateObj:
         location.source = "TEST"
         shared_state.set_location(location)
         shared_state.set_datetime(
-            datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2024, 1, 1, 12, 0, 0,
+                              tzinfo=datetime.timezone.utc),
             force=True,
         )
-        now = shared_state.datetime().timestamp() if shared_state.datetime() else 0
+        now = (shared_state.datetime().timestamp()
+               if shared_state.datetime() else 0)
         # A fresh camera plate-solve: both axes' solve and estimate cells are
-        # populated together (no IMU progression yet, so estimate == solve), and
-        # the eyepiece-aligned axis equals the camera axis (no alignment offset).
+        # populated together (no IMU progression yet, so estimate == solve),
+        # and the eyepiece-aligned axis equals the camera axis
+        # (no alignment offset).
         # Mirrors what the integrator produces from a SuccessfulSolve.
         direction = Pointing(RA=83.82, Dec=-5.39, Roll=0.0)
         solved = PointingEstimate(
@@ -538,9 +553,11 @@ def _sweep_stack(menu_manager: MenuManager, seen: set) -> None:
     """
     count = 0
     while count < _MAX_SWEEP_MODULES:
-        # MenuManager.stack is annotated list[type[UIModule]] upstream but holds
-        # instances; cast so the sweep sees them as the UIModule instances they are.
-        pending = [cast(UIModule, m) for m in menu_manager.stack if id(m) not in seen]
+        # MenuManager.stack is annotated list[type[UIModule]] upstream
+        # but holds instances; cast so the sweep sees them
+        # as the UIModule instances they are.
+        pending = [cast(UIModule, m)
+                   for m in menu_manager.stack if id(m) not in seen]
         if not pending:
             break
         for module in pending:
@@ -555,7 +572,8 @@ def _sweep_stack(menu_manager: MenuManager, seen: set) -> None:
                 break
 
 
-def _build_and_exercise(item_definition, state, display, camera_image, catalogs):
+def _build_and_exercise(item_definition, state, display,
+                        camera_image, catalogs):
     """Construct a module through a real MenuManager and exercise it."""
     cfg = Config()
     shared_state = _make_shared_state(state)
@@ -570,8 +588,8 @@ def _build_and_exercise(item_definition, state, display, camera_image, catalogs)
         display, camera_image, shared_state, command_queues, cfg, catalogs
     )
 
-    # Ignore whatever MenuManager pushed at construction (the root menu); only
-    # exercise the module under test and anything it pushes.
+    # Ignore whatever MenuManager pushed at construction (the root menu);
+    # only exercise the module under test and anything it pushes.
     seen = {id(m) for m in menu_manager.stack}
     menu_manager.add_to_stack(copy.deepcopy(item_definition))
     _sweep_stack(menu_manager, seen)
@@ -588,7 +606,8 @@ def _build_and_exercise(item_definition, state, display, camera_image, catalogs)
 def test_menu_node_module(
     node, state, display, camera_image, catalogs, hip_main_available
 ):
-    """Every menu-tree node with a class constructs and survives a key sweep."""
+    """Every menu-tree node with a class constructs
+    and survives a key sweep."""
     class_name = _resolve_class_name(node["class"])
     if class_name in _SWEEP_SKIP:
         pytest.skip(_SWEEP_SKIP[class_name])
@@ -601,21 +620,25 @@ def test_menu_node_module(
 @pytest.mark.parametrize("state", ["cold", "warm"])
 @pytest.mark.parametrize("spec_id", _DYNAMIC_IDS)
 def test_dynamic_ui_module(
-    spec_id, state, display, camera_image, catalogs, sample_object, hip_main_available
+    spec_id, state, display, camera_image, catalogs, sample_object,
+    hip_main_available
 ):
     """Dynamically-pushed modules construct and survive a key sweep."""
     item_definition = _build_dynamic_item_definition(spec_id, sample_object)
-    if item_definition["class"].__name__ in _HIP_REQUIRED and not hip_main_available:
+    if (item_definition["class"].__name__ in _HIP_REQUIRED
+            and not hip_main_available):
         pytest.skip("hip_main.dat unavailable (needed by chart/align)")
-    _build_and_exercise(item_definition, state, display, camera_image, catalogs)
+    _build_and_exercise(item_definition, state, display, camera_image,
+                        catalogs)
 
 
 @pytest.mark.integration
 def test_all_ui_modules_covered():
     """Fail if a UIModule subclass is reached by neither discovery path.
 
-    Guards against a newly-added screen silently escaping smoke coverage. Known,
-    deliberate exceptions live in _COVERAGE_SKIP with a documented reason.
+    Guards against a newly-added screen silently escaping smoke coverage.
+    Known, deliberate exceptions live in _COVERAGE_SKIP
+    with a documented reason.
     """
     covered = {_resolve_class_name(node["class"]) for node in _MENU_NODES}
     covered |= set(_DYNAMIC_IDS)
@@ -625,6 +648,6 @@ def test_all_ui_modules_covered():
 
     assert not uncovered, (
         "UIModule subclasses with no smoke coverage: "
-        f"{sorted(uncovered)}. Wire them into the menu tree, add a fixture to "
-        "_DYNAMIC_IDS, or document an exception in _COVERAGE_SKIP."
+        f"{sorted(uncovered)}. Wire them into the menu tree, add a fixture"
+        " to _DYNAMIC_IDS, or document an exception in _COVERAGE_SKIP."
     )


### PR DESCRIPTION
correction_targets now hops into Alt/Az space to better model how to turn mount Alt/Az adjustment knobs (assuming Az adjustments sit under the Alt one) and back into RA/Dec scape. The unit tests now need to supply latitude and local sidereal time to the routine.