### PR TITLE
Anchor file paths on repo root; share 320x240 layout profile

### DIFF
--- a/python/PiFinder/config.py
+++ b/python/PiFinder/config.py
@@ -29,10 +29,9 @@ class Config:
         Loads all config from disk useful if another
         process has changed config
         """
-        cwd = Path.cwd()
         self.config_file_path = Path(utils.data_dir, "config.json")
 
-        self.default_file_path = Path(cwd, "../default_config.json")
+        self.default_file_path = Path(utils.pifinder_dir, "default_config.json")
         if not os.path.exists(self.config_file_path):
             self._config_dict = {}
         else:

--- a/python/PiFinder/displays.py
+++ b/python/PiFinder/displays.py
@@ -90,16 +90,37 @@ class DisplayPygame_128(DisplayBase):
         super().__init__()
 
 
-class DisplayPygame_320(DisplayBase):
+class Layout320:
+    """Shared 320x240 layout profile for the ST7789 LCD.
+
+    Every 320 render target — the real LCD, the pygame emulator, and the
+    headless dummy — must lay out identically for the emulator to faithfully
+    preview the hardware (same role as ``Layout176`` for the 1.91" panel).
+    """
+
     resolution = (320, 240)
+    titlebar_height = 22
+    base_font_size = 16
+    bold_font_size = 19
+    small_font_size = 13
+    large_font_size = 24
+    huge_font_size = 70
+
+
+class DisplayPygame_320(Layout320, DisplayBase):
+    """Pygame emulator at 320x240 with the ST7789 layout profile.
+
+    Lets the LCD UI be previewed on a dev machine with no Pi/panel; the
+    ``Layout320`` profile means it renders with the same fonts/spacing as the
+    real LCD. Select with ``--display pg_320``.
+    """
 
     def __init__(self):
         from luma.emulator.device import pygame
 
-        # init display  (SPI hardware)
         pygame = pygame(
-            width=320,
-            height=240,
+            width=self.resolution[0],
+            height=self.resolution[1],
             rotate=0,
             mode="RGB",
             frame_rate=60,
@@ -227,15 +248,7 @@ class DisplayST7789_128(DisplayBase):
         super().__init__()
 
 
-class DisplayST7789(DisplayBase):
-    resolution = (320, 240)
-    titlebar_height = 22
-    base_font_size = 16
-    bold_font_size = 19
-    small_font_size = 13
-    large_font_size = 24
-    huge_font_size = 70
-
+class DisplayST7789(Layout320, DisplayBase):
     def __init__(self):
         # init display  (SPI hardware)
         serial = spi(device=0, port=0, bus_speed_hz=52000000)
@@ -288,12 +301,23 @@ class DisplayHeadless176(Layout176, DisplayHeadless):
     """
 
 
+class DisplayHeadless320(Layout320, DisplayHeadless):
+    """Headless (luma ``dummy``) display at 320x240 with the ST7789 layout.
+
+    The no-hardware target for driving/screenshotting the LCD UI over the
+    HTTP API. Select with ``--display headless_320``.
+    """
+
+
 def get_display(display_hardware: str) -> DisplayBase:
     if display_hardware == "headless":
         return DisplayHeadless()
 
     if display_hardware == "headless_176":
         return DisplayHeadless176()
+
+    if display_hardware == "headless_320":
+        return DisplayHeadless320()
 
     if display_hardware == "pg_128":
         return DisplayPygame_128()

--- a/python/PiFinder/gps_fake.py
+++ b/python/PiFinder/gps_fake.py
@@ -12,6 +12,7 @@ import time
 import datetime
 import logging
 
+from PiFinder import utils
 from PiFinder.multiproclogging import MultiprocLogging
 from PiFinder.gps_ubx_parser import UBXParser
 from PiFinder.gps_ubx import process_messages
@@ -65,8 +66,7 @@ def gps_monitor(gps_queue, console_queue, log_queue, file_name="test.ubx"):
     time.sleep(5)
 
     try:
-        dir = "../test_ubx/"
-        f_path = os.path.join(dir, file_name)
+        f_path = str(utils.pifinder_dir / "test_ubx" / file_name)
         if os.path.isfile(f_path):
             logger.error(f"Read ubx from {f_path}")
 

--- a/python/PiFinder/main.py
+++ b/python/PiFinder/main.py
@@ -454,7 +454,7 @@ def main(
         )
         keyboard_process.start()
         if script_name:
-            script_path = f"../scripts/{script_name}.pfs"
+            script_path = str(utils.pifinder_dir / "scripts" / f"{script_name}.pfs")
             p = Process(
                 name="Script",
                 target=keyboard_interface.KeyboardInterface.run_script,

--- a/python/PiFinder/server.py
+++ b/python/PiFinder/server.py
@@ -183,15 +183,17 @@ class Server:
         # Static files routes
         @app.route("/images/<path:filename>")
         def send_image(filename):
-            return send_file(f"../views/images/{filename}", mimetype="image/png")
+            return send_file(
+                os.path.join(views2_path, "images", filename), mimetype="image/png"
+            )
 
         @app.route("/js/<path:filename>")
         def send_js(filename):
-            return send_file(f"../views/js/{filename}")
+            return send_file(os.path.join(views2_path, "js", filename))
 
         @app.route("/css/<path:filename>")
         def send_css(filename):
-            return send_file(f"../views/css/{filename}")
+            return send_file(os.path.join(views2_path, "css", filename))
 
         @app.route("/")
         def home():

--- a/python/PiFinder/solver.py
+++ b/python/PiFinder/solver.py
@@ -346,9 +346,7 @@ def solver(
 ):
     MultiprocLogging.configurer(log_queue)
     logger.debug("Starting Solver")
-    t3 = tetra3.Tetra3(
-        str(utils.cwd_dir / "PiFinder/tetra3/tetra3/data/default_database.npz")
-    )
+    t3 = tetra3.Tetra3(str(utils.tetra3_dir / "data" / "default_database.npz"))
     align_ra = 0
     align_dec = 0
     last_solve_attempt: float = 0.0

--- a/python/PiFinder/ui/fonts.py
+++ b/python/PiFinder/ui/fonts.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 from PIL import ImageFont
-from PiFinder import config
+from PiFinder import config, utils
 
 
 class Font:
@@ -50,7 +50,7 @@ class Fonts:
         huge_size=35,
         screen_width=128,
     ):
-        font_path = str(Path(Path.cwd(), "../fonts"))
+        font_path = str(Path(utils.pifinder_dir, "fonts"))
 
         # Check for chinese language specifically
         cfg = config.Config()

--- a/python/PiFinder/utils.py
+++ b/python/PiFinder/utils.py
@@ -7,9 +7,11 @@ import importlib
 
 
 home_dir = Path.home()
-cwd_dir = Path.cwd()
-pifinder_dir = Path("..")
-astro_data_dir = cwd_dir / pifinder_dir / "astro_data"
+# Repo root, anchored on this file (python/PiFinder/utils.py) so paths
+# resolve regardless of cwd. All other modules derive paths from here.
+pifinder_dir = Path(__file__).resolve().parents[2]
+assert (pifinder_dir / "astro_data").is_dir(), f"repo root not at {pifinder_dir}"
+astro_data_dir = pifinder_dir / "astro_data"
 tetra3_dir = pifinder_dir / "python/PiFinder/tetra3/tetra3"
 data_dir = Path(Path.home(), "PiFinder_data")
 pifinder_db = astro_data_dir / "pifinder_objects.db"


### PR DESCRIPTION
## Summary

Two related cleanups:

### Path resolution (`fix(paths)`)
`utils.pifinder_dir` is now derived from `utils.py`'s own location instead of `Path.cwd()`, with a one-line assert that fails loudly if the file ever moves. All other cwd-relative paths in the codebase now derive from it:

- `solver.py` — tetra3 `default_database.npz`
- `config.py` — `default_config.json`
- `ui/fonts.py` — fonts directory
- `main.py` — `.pfs` script paths
- `gps_fake.py` — `test_ubx` recordings
- `server.py` — images/js/css static routes (reuse the absolute views path the templates already use)

Previously everything silently assumed `cwd == python/`; PiFinder modules can now be imported (and the app started) from any directory.

### Display layout (`refactor(displays)`)
`DisplayST7789`'s hand-tuned layout moves into a `Layout320` mixin (mirroring `Layout176`), now shared with the `pg_320` emulator — which was previewing the LCD with the 128-panel fonts. Also adds a `headless_320` display so the LCD UI can be driven and screenshotted over the HTTP API like `headless_176`.

## Testing

- ruff lint + format clean, mypy clean (161 files)
- 299 smoke + unit tests pass
- Imported `config`/`fonts`/`displays` from a foreign cwd (`/tmp`) — all paths resolve
- Booted the full app headless at `headless_320`: home screen renders with the ST7789 layout profile, web static routes serve correctly