### PR TITLE
fix(nixos): reliable WiFi AP fallback, clearer offline UX, surface sys_utils failures

### DIFF
--- a/nixos/networking.nix
+++ b/nixos/networking.nix
@@ -56,4 +56,46 @@
     '';
     mode = "0600";
   };
+
+  # AP fallback / persistence. The PiFinder-AP profile has a low autoconnect
+  # priority, so NetworkManager prefers a known client network when one is
+  # reachable. This service makes the AP a reliable fallback: it brings the AP
+  # up when no client connects within a grace period (so a device with a saved
+  # but-unreachable network is still reachable), and when the user has forced AP
+  # mode in the UI (persisted to PiFinder_data/wifi_mode).
+  systemd.services.pifinder-wifi-fallback = {
+    description = "Bring up PiFinder AP when no WiFi client is connected";
+    after = [ "NetworkManager.service" ];
+    wants = [ "NetworkManager.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = [ pkgs.networkmanager pkgs.coreutils pkgs.gnugrep ];
+    serviceConfig.Type = "oneshot";
+    script = ''
+      modefile=/home/pifinder/PiFinder_data/wifi_mode
+
+      if [ -r "$modefile" ] && [ "$(cat "$modefile")" = "AP" ]; then
+        nmcli connection up PiFinder-AP || true
+        exit 0
+      fi
+
+      # Give NetworkManager up to 45s to join a known client network.
+      for _ in $(seq 1 45); do
+        if nmcli -t -f TYPE,STATE device | grep -q '^wifi:connected'; then
+          exit 0
+        fi
+        sleep 1
+      done
+
+      nmcli connection up PiFinder-AP || true
+    '';
+  };
+
+  systemd.timers.pifinder-wifi-fallback = {
+    description = "Periodically ensure WiFi falls back to AP when offline";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "30s";
+      OnUnitActiveSec = "120s";
+    };
+  };
 }

--- a/python/PiFinder/sys_utils.py
+++ b/python/PiFinder/sys_utils.py
@@ -271,12 +271,28 @@ class Network(NetworkBase):
         (data_dir / "hostname").write_text(hostname)
 
     def _go_ap(self) -> None:
-        """Activate the AP connection."""
+        """Activate the AP connection and remember the choice across reboots."""
+        self._persist_wifi_mode("AP")
         self._activate_connection(AP_CONNECTION_NAME)
 
     def _go_client(self) -> None:
         """Deactivate the AP connection (fall back to client)."""
+        self._persist_wifi_mode("Client")
         self._deactivate_connection(AP_CONNECTION_NAME)
+
+    @staticmethod
+    def _persist_wifi_mode(mode: str) -> None:
+        """Persist the desired WiFi mode for the boot-time fallback service.
+
+        The PiFinder-AP NetworkManager profile has a low autoconnect priority,
+        so a forced AP would otherwise be lost on reboot; the fallback service
+        reads this file to restore it.
+        """
+        data_dir = Path(os.environ.get("PIFINDER_DATA", "/home/pifinder/PiFinder_data"))
+        try:
+            (data_dir / "wifi_mode").write_text(mode)
+        except OSError as e:
+            logger.warning("Could not persist WiFi mode %r: %s", mode, e)
 
     def _activate_connection(self, name: str) -> None:
         """Activate a saved connection by name."""

--- a/python/PiFinder/ui/software.py
+++ b/python/PiFinder/ui/software.py
@@ -130,6 +130,7 @@ def _fetch_github_releases() -> tuple[list[dict], list[dict]]:
 
     except requests.exceptions.RequestException as e:
         logger.warning("Could not fetch GitHub releases: %s", e)
+        raise
 
     return stable, beta
 
@@ -283,7 +284,12 @@ class UISoftware(UIModule):
     # ------------------------------------------------------------------
 
     def _fetch_channels(self):
-        stable, beta = _fetch_github_releases()
+        try:
+            stable, beta = _fetch_github_releases()
+        except requests.exceptions.RequestException as e:
+            logger.warning("Software update check failed (offline?): %s", e)
+            self._phase = "offline"
+            return
 
         self._channels = {
             "stable": stable,
@@ -424,6 +430,29 @@ class UISoftware(UIModule):
         self.draw.text(
             (10, 105),
             _("client mode"),
+            font=self.fonts.large.font,
+            fill=self.colors.get(255),
+        )
+
+    def _draw_offline(self):
+        y = self.display_class.titlebar_height + 2
+        ver_scroller = self._get_scroller(
+            "offline_ver",
+            self._software_version,
+            self.fonts.bold,
+            self.colors.get(255),
+            self.fonts.bold.line_length,
+        )
+        ver_scroller.draw((0, y))
+        self.draw.text(
+            (10, 90),
+            _("No internet -"),
+            font=self.fonts.large.font,
+            fill=self.colors.get(255),
+        )
+        self.draw.text(
+            (10, 105),
+            _("check WiFi"),
             font=self.fonts.large.font,
             fill=self.colors.get(255),
         )
@@ -660,10 +689,14 @@ class UISoftware(UIModule):
         if self._phase == "loading":
             if self._elipsis_count > 30:
                 self._fetch_channels()
-                # phase is now "browse", fall through
+                # phase is now "browse" or "offline", fall through
             else:
                 self._draw_loading()
                 return self.screen_update()
+
+        if self._phase == "offline":
+            self._draw_offline()
+            return self.screen_update()
 
         if self._phase == "browse":
             self._draw_browse()

--- a/python/PiFinder/utils.py
+++ b/python/PiFinder/utils.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Optional
 import importlib
 
+logger = logging.getLogger("Utils")
+
 
 home_dir = Path.home()
 # Repo root, anchored on this file (python/PiFinder/utils.py) so paths
@@ -224,6 +226,11 @@ def get_sys_utils():
     try:
         return importlib.import_module("PiFinder.sys_utils")
     except Exception:
+        logger.warning(
+            "PiFinder.sys_utils failed to import; falling back to the no-op "
+            "fake. WiFi/AP/hostname/reboot controls will not work.",
+            exc_info=True,
+        )
         return importlib.import_module("PiFinder.sys_utils_fake")
 
 

--- a/switch-ap.sh
+++ b/switch-ap.sh
@@ -1,8 +1,0 @@
-#! /usr/bin/bash
-cp /etc/dhcpcd.conf.ap /etc/dhcpcd.conf
-systemctl enable dnsmasq
-systemctl enable hostapd
-echo -n "AP" > /home/pifinder/PiFinder/wifi_status.txt
-#systemctl start dnsmasq
-#systemctl start hostapd
-#systemctl restart dhcpcd

--- a/switch-cli.sh
+++ b/switch-cli.sh
@@ -1,8 +1,0 @@
-#! /usr/bin/bash
-#systemctl stop dnsmasq
-#systemctl stop hostapd
-cp /etc/dhcpcd.conf.sta /etc/dhcpcd.conf
-systemctl disable dnsmasq
-systemctl disable hostapd
-#systemctl restart dhcpcd
-echo -n "Client" > /home/pifinder/PiFinder/wifi_status.txt


### PR DESCRIPTION
## What

Fixes the WiFi/system-management issues found while debugging "device shows
nothing on the unstable channel" — the real cause was the device being offline,
which surfaced several gaps.

## Changes

- **`networking.nix` — reliable AP fallback.** New `pifinder-wifi-fallback`
  oneshot + timer brings up `PiFinder-AP` when no WiFi client connects within a
  45s grace period (or when AP is forced in the UI). Previously the AP profile's
  low `autoconnect-priority` (-1) meant NetworkManager kept retrying a saved-but-
  unreachable client network and never fell back to AP → the device was neither
  online nor reachable via AP. The timer re-checks every 120s so a mid-session
  client drop also falls back.
- **`sys_utils.py` — AP survives reboot.** `_go_ap`/`_go_client` persist the
  chosen mode to `PiFinder_data/wifi_mode`; the fallback service restores a
  forced AP after reboot.
- **`software.py` — offline UX.** The Software-update screen now shows
  "No internet - check WiFi" instead of an empty channel list when GitHub is
  unreachable (connection errors propagate to a new `offline` phase).
- **`utils.py` — stop hiding failures.** `get_sys_utils()` logged nothing when
  it fell back to the no-op `sys_utils_fake`; it now logs the import error with a
  traceback, so a failed `gi.repository.NM` / `dbus` / `pam` import on-device is
  diagnosable instead of silently disabling all WiFi/AP/hostname controls.
- **Remove dead scripts.** `switch-ap.sh` / `switch-cli.sh` were Raspberry Pi OS
  (dhcpcd/hostapd) and are inert on NixOS.

## Verified

- `ruff format` / `ruff check` clean on the changed Python.
- `nix eval … .drvPath` succeeds for the `pifinder` config with the new units.
- **Not** tested on hardware — the AP fallback timing and forced-mode behaviour
  need on-device validation (label `testable` on the brickbots side to push it to
  a device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
